### PR TITLE
Cat-egory selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.12.3",
+    "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",

--- a/src/App.css
+++ b/src/App.css
@@ -3,7 +3,8 @@
 }
 
 .App-logo {
-  height: 50vmin;
+  width: 80vmin;
+  max-height: 70vmin;
   pointer-events: none;
 }
 
@@ -18,10 +19,16 @@
   color: black;
 }
 
-.App-tools {
-  margin: 10px;
+.App-select {
+  min-width: 80px;
 }
 
-.App-link {
-  color: #61dafb;
+.App-tools {
+  margin: 10px;
+  display: flex;
+}
+
+.App-spacer {
+  margin: auto;
+  padding: 4px;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,9 @@
-import { Component } from 'react';
+import { React, Component } from 'react';
 import { Button } from '@material-ui/core';
+import PetsIcon from '@material-ui/icons/Pets';
+
 import './App.css';
+import CatEgorySelector from './components/CatEgorySelector';
 
 import catloading from './img/catloading.gif';
 import caterror from './img/caterror.gif';
@@ -9,7 +12,8 @@ export default class App extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      currentCat: catloading,
+      currentCatUrl: catloading,
+      categoryId: 0,
     };
   }
 
@@ -22,17 +26,30 @@ export default class App extends Component {
       <div className="App">
         <header className="App-header">
           <img
-            src={this.state.currentCat}
+            src={this.state.currentCatUrl}
             className="App-logo"
             alt="hopefully a cat"
           />
           <div className="App-tools">
-            <Button
-              variant="contained"
-              color="primary"
-              onClick={this.getNewCatUrl}>
-              New Cat Please!
-            </Button>
+            <div className="App-spacer">
+              <CatEgorySelector
+                onCatEgoryChange={(value) => {
+                  this.setState({ categoryId: value }, () =>
+                    this.getNewCatUrl()
+                  );
+                }}
+                catEgorySelected={this.state.categoryId}></CatEgorySelector>
+            </div>
+            <div className="App-spacer">
+              <Button
+                variant="contained"
+                size="large"
+                color="primary"
+                onClick={this.getNewCatUrl}
+                startIcon={<PetsIcon />}>
+                New Cat Please!
+              </Button>
+            </div>
           </div>
         </header>
       </div>
@@ -40,8 +57,12 @@ export default class App extends Component {
   }
 
   getNewCatUrl = () => {
-    this.setState({ currentCat: catloading });
-    fetch('https://api.thecatapi.com/v1/images/search', {
+    this.setState({ currentCatUrl: catloading });
+    var fetchUrl = 'https://api.thecatapi.com/v1/images/search';
+    if (this.state.categoryId > 0)
+      fetchUrl += '?category_ids=' + this.state.categoryId;
+    console.log(fetchUrl);
+    fetch(fetchUrl, {
       method: 'GET',
       headers: {
         'x-api-key': process.env.REACT_APP_CAT_API_KEY,
@@ -52,9 +73,9 @@ export default class App extends Component {
       .then((response) => response.json())
       .then((response) => {
         if (response.length > 0) {
-          this.setState({ currentCat: response[0].url });
+          this.setState({ currentCatUrl: response[0].url });
         } else {
-          this.setState({ currentCat: caterror });
+          this.setState({ currentCatUrl: caterror });
         }
       });
   };

--- a/src/components/CatEgorySelector.js
+++ b/src/components/CatEgorySelector.js
@@ -1,0 +1,61 @@
+import { React, Component } from 'react';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+
+/** props
+ * catEgorySelected - currently selected value
+ * onCatEgoryChange - callback function
+ */
+export default class CatEgorySelector extends Component {
+  constructor(props) {
+    super(props);
+    this.handleChange = this.handleChange.bind(this);
+    this.state = {
+      catEgories: [],
+    };
+  }
+
+  handleChange(event) {
+    this.props.onCatEgoryChange(event.target.value);
+  }
+
+  componentDidMount() {
+    fetch('https://api.thecatapi.com/v1/categories', {
+      method: 'GET',
+      headers: {
+        'x-api-key': process.env.REACT_APP_CAT_API_KEY,
+        'content-type': 'application/json',
+        accept: 'application/json',
+      },
+    })
+      .then((response) => response.json())
+      .then((response) => {
+        this.setState({ catEgories: response });
+      });
+  }
+
+  render() {
+    const catEgorySelected = this.props.catEgorySelected;
+    return (
+      <FormControl variant="outlined">
+        <InputLabel id="cat-egory-select-label">Cat-egory</InputLabel>
+        <Select
+          id="cat-egory-select"
+          value={catEgorySelected}
+          onChange={this.handleChange}
+          label="Cat-egory">
+          <MenuItem key="0" value="0">
+            <em>All Categories</em>
+          </MenuItem>
+          {this.state.catEgories.map(({ id, name }) => (
+            <MenuItem key={id} value={id}>
+              {name}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    );
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,6 +1430,13 @@
     react-is "^16.8.0 || ^17.0.0"
     react-transition-group "^4.4.0"
 
+"@material-ui/icons@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
+  integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+
 "@material-ui/styles@^4.11.4":
   version "4.11.4"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.4.tgz#eb9dfccfcc2d208243d986457dff025497afa00d"


### PR DESCRIPTION
Can now choose a category for your cat. Go me.

**TODO!** Probably need to update to `@mui/material@next` (v5 Material UI) because we're getting `findDOMNode is deprecated in StrictMode` errors from the dropdown component.